### PR TITLE
#6 [fix] encoding を引数で受け取る

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -19,27 +19,27 @@
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
-                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
+                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==21.2.0"
+            "version": "==21.4.0"
         },
         "autopep8": {
             "hashes": [
-                "sha256:276ced7e9e3cb22e5d7c14748384a5cf5d9002257c0ed50c0e075b68011bb6d0",
-                "sha256:aa213493c30dcdac99537249ee65b24af0b2c29f2e83cd8b3f68760441ed0db9"
+                "sha256:44f0932855039d2c15c4510d6df665e4730f2b8582704fa48f9c55bd3e17d979",
+                "sha256:ed77137193bbac52d029a52c59bec1b0629b5a186c495f1eb21b126ac466083f"
             ],
             "index": "pypi",
-            "version": "==1.5.7"
+            "version": "==1.6.0"
         },
         "flake8": {
             "hashes": [
-                "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b",
-                "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"
+                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
+                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
             ],
             "index": "pypi",
-            "version": "==3.9.2"
+            "version": "==4.0.1"
         },
         "iniconfig": {
             "hashes": [
@@ -57,11 +57,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
-                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==21.0"
+            "version": "==21.3"
         },
         "pluggy": {
             "hashes": [
@@ -73,35 +73,35 @@
         },
         "py": {
             "hashes": [
-                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
-                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.10.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068",
-                "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"
+                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
+                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.7.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.8.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3",
-                "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"
+                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
+                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.3.1"
+            "version": "==2.4.0"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
+                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.4.7"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.6"
         },
         "pytest": {
             "hashes": [

--- a/jcon/func_decorator.py
+++ b/jcon/func_decorator.py
@@ -1,6 +1,6 @@
-from functools import wraps
-from typing import Callable
 from .json_context import json_read
+from functools import wraps
+from typing import Optional, Callable
 
 
 def configurable(func: Callable) -> Callable[[str], Callable]:
@@ -13,8 +13,8 @@ def configurable(func: Callable) -> Callable[[str], Callable]:
         Callable[[str], Callable]: Wrapped function which is input from ``.json`` path.
     """
     @wraps(func)
-    def wrapper(json_path: str, *args, **kwargs):
-        with json_read(json_path) as json_dict:
+    def wrapper(json_path: str, encoding: Optional[str] = None, *args, **kwargs):
+        with json_read(json_path, encoding=encoding) as json_dict:
             return func(*args, **kwargs, **json_dict)
 
     return wrapper

--- a/jcon/func_decorator.py
+++ b/jcon/func_decorator.py
@@ -1,10 +1,24 @@
-from _typeshed import OpenTextMode
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _typeshed import OpenTextMode
+
 from .json_context import json_read
 from functools import wraps
 from typing import Optional, Callable
 
 
-def configurable(func: Callable) -> Callable[[str], Callable]:
+def configurable(
+    _func: Optional[Callable] = None,
+    mode: Optional[OpenTextMode] = 'r',
+    buffering: Optional[int] = -1,
+    encoding: Optional[str] = None,
+    errors: Optional[str] = None,
+    newline: Optional[str] = None,
+    closefd: Optional[bool] = True,
+    opener: Optional[Callable] = None,
+):
     """Make your function configurable by ``.json`` path.
 
     Args:
@@ -13,32 +27,53 @@ def configurable(func: Callable) -> Callable[[str], Callable]:
     Returns:
         Callable[[str], Callable]: Wrapped function which is input from ``.json`` path.
     """
-    @wraps(func)
-    def wrapper(
-        json_path: str,
-        mode: Optional[OpenTextMode] = 'r',
-        buffering: Optional[int] = -1,
-        encoding: Optional[str] = None,
-        errors: Optional[str] = None,
-        newline: Optional[str] = None,
-        closefd: Optional[bool] = True,
-        opener: Optional[Callable] = None,
-        *args,
-        **kwargs
-    ):
-        with json_read(
-            json_path,
-            mode=mode,
-            buffering=buffering,
-            encoding=encoding,
-            errors=errors,
-            newline=newline,
-            closefd=closefd,
-            opener=opener,
-        ) as json_dict:
-            return func(*args, **kwargs, **json_dict)
 
-    return wrapper
+    if _func is None:
+        def _configurable(func: Callable) -> Callable[[str], Callable]:
+            @wraps(func)
+            def wrapper(
+                json_path: str,
+                *args,
+                **kwargs
+            ):
+                with json_read(
+                    json_path,
+                    mode=mode,
+                    buffering=buffering,
+                    encoding=encoding,
+                    errors=errors,
+                    newline=newline,
+                    closefd=closefd,
+                    opener=opener,
+                ) as json_dict:
+                    return func(*args, **kwargs, **json_dict)
+
+            return wrapper
+
+        return _configurable
+    else:
+        # avoid mypy error ( mypy says "None" not callable nonetheless this else scope ensure func is not None. )
+        func = _func
+
+        @wraps(func)
+        def wrapper(
+            json_path: str,
+            *args,
+            **kwargs
+        ):
+            with json_read(
+                json_path,
+                mode=mode,
+                buffering=buffering,
+                encoding=encoding,
+                errors=errors,
+                newline=newline,
+                closefd=closefd,
+                opener=opener,
+            ) as json_dict:
+                return func(*args, **kwargs, **json_dict)
+
+        return wrapper
 
 
 if __name__ == "__main__":

--- a/jcon/func_decorator.py
+++ b/jcon/func_decorator.py
@@ -1,3 +1,4 @@
+from _typeshed import OpenTextMode
 from .json_context import json_read
 from functools import wraps
 from typing import Optional, Callable
@@ -13,8 +14,28 @@ def configurable(func: Callable) -> Callable[[str], Callable]:
         Callable[[str], Callable]: Wrapped function which is input from ``.json`` path.
     """
     @wraps(func)
-    def wrapper(json_path: str, encoding: Optional[str] = None, *args, **kwargs):
-        with json_read(json_path, encoding=encoding) as json_dict:
+    def wrapper(
+        json_path: str,
+        mode: Optional[OpenTextMode] = 'r',
+        buffering: Optional[int] = -1,
+        encoding: Optional[str] = None,
+        errors: Optional[str] = None,
+        newline: Optional[str] = None,
+        closefd: Optional[bool] = True,
+        opener: Optional[Callable] = None,
+        *args,
+        **kwargs
+    ):
+        with json_read(
+            json_path,
+            mode=mode,
+            buffering=buffering,
+            encoding=encoding,
+            errors=errors,
+            newline=newline,
+            closefd=closefd,
+            opener=opener,
+        ) as json_dict:
             return func(*args, **kwargs, **json_dict)
 
     return wrapper

--- a/jcon/json_context.py
+++ b/jcon/json_context.py
@@ -12,7 +12,7 @@ def json_read(jsonpath: str, *args, **kwargs):
     Yields:
         ``dict``: return ``dict`` read from ``jsonpath``
     """
-    json_file = open(jsonpath, 'r', *args, **kwargs)
+    json_file = open(jsonpath, *args, **kwargs)
     try:
         yield json.load(json_file)
     finally:

--- a/jcon/json_context.py
+++ b/jcon/json_context.py
@@ -3,7 +3,7 @@ import contextlib
 
 
 @contextlib.contextmanager
-def json_read(jsonpath: str):
+def json_read(jsonpath: str, *args, **kwargs):
     """Context manager to yield ``dict`` from path in which .json is.
 
     Args:
@@ -12,7 +12,7 @@ def json_read(jsonpath: str):
     Yields:
         ``dict``: return ``dict`` read from ``jsonpath``
     """
-    json_file = open(jsonpath, 'r')
+    json_file = open(jsonpath, 'r', *args, **kwargs)
     try:
         yield json.load(json_file)
     finally:

--- a/jcon/registrable.py
+++ b/jcon/registrable.py
@@ -1,3 +1,5 @@
+from _typeshed import OpenTextMode
+
 import importlib
 import inspect
 from collections import defaultdict
@@ -163,7 +165,19 @@ class Registrable:
         return instance
 
     @classmethod
-    def from_json(cls: Type[T], json_path: str, encoding: Optional[str] = None, *args, **kwargs) -> Type[Instance]:
+    def from_json(
+        cls: Type[T],
+        json_path: str,
+        mode: Optional[OpenTextMode] = 'r',
+        buffering: Optional[int] = -1,
+        encoding: Optional[str] = None,
+        errors: Optional[str] = None,
+        newline: Optional[str] = None,
+        closefd: Optional[bool] = True,
+        opener: Optional[Callable] = None,
+        *args,
+        **kwargs
+    ) -> Type[Instance]:
         """Get instance with ``json`` initialization.
 
         Args:
@@ -173,7 +187,16 @@ class Registrable:
         Returns:
             Type[T]: incetance of subclass
         """
-        with json_read(json_path, encoding=encoding) as json_dict:
+        with json_read(
+            json_path,
+            mode=mode,
+            buffering=buffering,
+            encoding=encoding,
+            errors=errors,
+            newline=newline,
+            closefd=closefd,
+            opener=opener,
+        ) as json_dict:
             instance = cls.from_dict(  # type: ignore
                 json_dict, *args, **kwargs)
         return instance

--- a/jcon/registrable.py
+++ b/jcon/registrable.py
@@ -163,7 +163,7 @@ class Registrable:
         return instance
 
     @classmethod
-    def from_json(cls: Type[T], json_path: str, *args, **kwargs) -> Type[Instance]:
+    def from_json(cls: Type[T], json_path: str, encoding: Optional[str] = None, *args, **kwargs) -> Type[Instance]:
         """Get instance with ``json`` initialization.
 
         Args:
@@ -173,7 +173,7 @@ class Registrable:
         Returns:
             Type[T]: incetance of subclass
         """
-        with json_read(json_path) as json_dict:
+        with json_read(json_path, encoding=encoding) as json_dict:
             instance = cls.from_dict(  # type: ignore
                 json_dict, *args, **kwargs)
         return instance

--- a/jcon/registrable.py
+++ b/jcon/registrable.py
@@ -1,4 +1,8 @@
-from _typeshed import OpenTextMode
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _typeshed import OpenTextMode
 
 import importlib
 import inspect

--- a/tests/jcon/test_func_decorator.py
+++ b/tests/jcon/test_func_decorator.py
@@ -24,3 +24,13 @@ def test_configurable():
         func2(json_path, name="Jason", food="Apple")
     assert func3(json_path, food="Banana") is None
     assert func3(json_path, **{"food": "Chocolate"}) is None
+
+
+def test_configurable_argument():
+    """test function for ``configurable`` in ``jcon/func_decoretor.py``"""
+    @jcon.configurable(encoding="utf-8")
+    def func(name: str, age: int, subjects: List[str]) -> None:
+        print(f"{name} is {age}-year-old and studying {len(subjects)} subjects.")
+
+    json_path = "sample/simple.json"
+    assert func(json_path) is None

--- a/tests/jcon/test_json_context.py
+++ b/tests/jcon/test_json_context.py
@@ -7,3 +7,11 @@ def test_json_read():
         assert json_dict["age"] == 16
         assert json_dict["subjects"][0] == "math"
         assert json_dict["subjects"][1] == "english"
+
+
+def test_json_read_arguments():
+    with json_read("sample/simple.json", encoding="utf-8") as json_dict:
+        assert json_dict["name"] == "Bob"
+        assert json_dict["age"] == 16
+        assert json_dict["subjects"][0] == "math"
+        assert json_dict["subjects"][1] == "english"

--- a/tests/jcon/test_registrable.py
+++ b/tests/jcon/test_registrable.py
@@ -30,3 +30,23 @@ def test_registrable():
         assert json_dict['age'] == instance.age
         assert json_dict['subjects'] == instance.subjects
         assert 'type' in json_dict.keys()
+
+
+def test_registrable_argument():
+    class BaseCls(Registrable):
+        def __init__(self):
+            raise NotImplementedError
+
+    @BaseCls.register("test")
+    class SubCls(BaseCls):
+        def __init__(self, name: str, age: int, subjects: List[str]):
+            self.name = name
+            self.age = age
+            self.subjects = subjects
+
+    with json_read(PATH, encoding="utf-8") as json_dict:
+        instance = BaseCls.from_json(PATH)
+    assert isinstance(instance, SubCls)
+    assert json_dict['name'] == instance.name
+    assert json_dict['age'] == instance.age
+    assert json_dict['subjects'] == instance.subjects


### PR DESCRIPTION
`json_read` -> positional 引数と keyword 引数を unpacking で受け取るように
`configurable`, `Registrable` -> `json_read` がラップしている `open` の引数を受け取るように

`configurable` は引数を与える場合(この時 syntax suger の @ がこれまでの実装と compatible でない)とそうでない場合 (関数のみを受け取る場合) が存在するので，関数が与えられるかそうでないかで場合分けした (commit #6b80a0f)。